### PR TITLE
Add client_config blocks to data source: cdnetworks_domain.

### DIFF
--- a/cdnetworks/data_source_domain.go
+++ b/cdnetworks/data_source_domain.go
@@ -113,17 +113,12 @@ func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		plan.ClientConfig = &clientConfig{}
 	}
 
-	var username, apiKey string
 	initClient := false
-	if !(plan.ClientConfig.Username.IsUnknown() && plan.ClientConfig.Username.IsNull()) {
-		if username = plan.ClientConfig.Username.ValueString(); username != "" {
-			initClient = true
-		}
-	}
-	if !(plan.ClientConfig.ApiKey.IsUnknown() && plan.ClientConfig.ApiKey.IsNull()) {
-		if apiKey = plan.ClientConfig.ApiKey.ValueString(); apiKey != "" {
-			initClient = true
-		}
+	username := plan.ClientConfig.Username.ValueString()
+	apiKey := plan.ClientConfig.ApiKey.ValueString()
+
+	if username != "" || apiKey != "" {
+		initClient = true
 	}
 
 	if initClient {

--- a/cdnetworks/data_source_domain.go
+++ b/cdnetworks/data_source_domain.go
@@ -30,6 +30,7 @@ type domainDataSource struct {
 }
 
 type domainDataSourceModel struct {
+	ClientConfig *clientConfig `tfsdk:"client_config"`
 	DomainName   types.String  `tfsdk:"domain_name"`
 	DomainCname  types.String  `tfsdk:"domain_cname"`
 	OriginConfig *originConfig `tfsdk:"origin_config"`
@@ -37,6 +38,11 @@ type domainDataSourceModel struct {
 
 type originConfig struct {
 	OriginIps types.List `tfsdk:"origin_ips"`
+}
+
+type clientConfig struct {
+	Username types.String `tfsdk:"username"`
+	ApiKey   types.String `tfsdk:"api_key"`
 }
 
 func (d *domainDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -66,6 +72,24 @@ func (d *domainDataSource) Schema(_ context.Context, req datasource.SchemaReques
 				},
 			},
 		},
+		Blocks: map[string]schema.Block{
+			"client_config": schema.SingleNestedBlock{
+				Description: "Config to override default client created in Provider. " +
+					"This block will not be recorded in state file.",
+				Attributes: map[string]schema.Attribute{
+					"username": schema.StringAttribute{
+						Description: "The username of CDNetworks account. Default " +
+							"to use username configured in the provider.",
+						Optional: true,
+					},
+					"api_key": schema.StringAttribute{
+						Description: "The api key of CDNetworks account. Default " +
+							"to use api key configured in the provider.",
+						Optional: true,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -78,11 +102,46 @@ func (d *domainDataSource) Configure(_ context.Context, req datasource.Configure
 }
 
 func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var plan, state domainDataSourceModel
+	var plan, state *domainDataSourceModel
 	diags := req.Config.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if plan.ClientConfig == nil {
+		plan.ClientConfig = &clientConfig{}
+	}
+
+	var username, apiKey string
+	initClient := false
+	if !(plan.ClientConfig.Username.IsUnknown() && plan.ClientConfig.Username.IsNull()) {
+		if username = plan.ClientConfig.Username.ValueString(); username != "" {
+			initClient = true
+		}
+	}
+	if !(plan.ClientConfig.ApiKey.IsUnknown() && plan.ClientConfig.ApiKey.IsNull()) {
+		if apiKey = plan.ClientConfig.ApiKey.ValueString(); apiKey != "" {
+			initClient = true
+		}
+	}
+
+	if initClient {
+		if username == "" {
+			username = d.client.Username
+		}
+		if apiKey == "" {
+			apiKey = d.client.ApiKey
+		}
+		var err error
+		if d.client, err = cdnetworksapi.NewClient(username, apiKey); err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to Reinitialize CDNetworks API Client",
+				"This is an error in provider, please contact the provider developers.\n\n"+
+					"Error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	domainName := plan.DomainName.ValueString()
@@ -118,6 +177,11 @@ func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return nil
 	}
 
+	state = &domainDataSourceModel{
+		OriginConfig: &originConfig{
+			OriginIps: types.ListNull(types.StringType),
+		},
+	}
 	// Retry backoff
 	reconnectBackoff := backoff.NewExponentialBackOff()
 	reconnectBackoff.MaxElapsedTime = 10 * time.Minute

--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -25,10 +25,23 @@ data "st-cdnetworks_domain" "cdn_domain" {
 
 - `domain_name` (String) Domain name of domain.
 
+### Optional
+
+- `client_config` (Block, Optional) Config to override default client created in Provider. This block will not be recorded in state file. (see [below for nested schema](#nestedblock--client_config))
+
 ### Read-Only
 
 - `domain_cname` (String) Domain Cname of domain.
 - `origin_config` (Object) Origin configuration of domain. (see [below for nested schema](#nestedatt--origin_config))
+
+<a id="nestedblock--client_config"></a>
+### Nested Schema for `client_config`
+
+Optional:
+
+- `username` (String) The username of CDNetworks account. Default to use username configured in the provider.
+- `api_key` (String) The api key of CDNetworks account. Default to use api key configured in the provider.
+
 
 <a id="nestedatt--origin_config"></a>
 ### Nested Schema for `origin_config`


### PR DESCRIPTION
The client_config block will override the Provider config, with any of the arguments specified in data sources: 
```
{
  username: string
  api_key: string
}
```

Affected Data Sources:
- `st-cdnetworks_domain`