### PR TITLE
Fix concurrency error, adding mutex lock to execute create one by one.

### DIFF
--- a/cdnetworks/provider.go
+++ b/cdnetworks/provider.go
@@ -3,8 +3,7 @@ package cdnetworks
 import (
 	"context"
 	"os"
-
-	"github.com/myklst/terraform-provider-st-cdnetworks/cdnetworksapi"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -12,11 +11,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/myklst/terraform-provider-st-cdnetworks/cdnetworksapi"
 )
 
 // Ensure the implementation satisfies the expected interfaces
 var (
-	_ provider.Provider = &cdnetworksProvider{}
+	_     provider.Provider = &cdnetworksProvider{}
+	mutex sync.Mutex
 )
 
 // New is a helper function to simplify provider server

--- a/cdnetworks/resource_flood_shield_domain.go
+++ b/cdnetworks/resource_flood_shield_domain.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/myklst/terraform-provider-st-cdnetworks/cdnetworks/common"
 	. "github.com/myklst/terraform-provider-st-cdnetworks/cdnetworks/model"
 	"github.com/myklst/terraform-provider-st-cdnetworks/cdnetworks/utils"
@@ -46,8 +45,14 @@ func (r *floodShieldDomainResource) Configure(ctx context.Context, req resource.
 }
 
 func (r *floodShieldDomainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var model *DomainResourceModel
+	// Add mutex lock to make sure the resources is created 1 by 1.
+	// As BindControlGroup API might get overwritten.
+	mutex.Lock()
+	defer func() {
+		mutex.Unlock()
+	}()
 
+	var model *DomainResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
Adding `mutex.lock`. Each domains creation is executed sequentially one after one.